### PR TITLE
Updates TESTs Import endpoint urls

### DIFF
--- a/docker_environment/run.sh
+++ b/docker_environment/run.sh
@@ -7,7 +7,9 @@ source ./config.sh
 # For more info, run : docker run --help
 # --publish list : Publish a container's port(s) to the host
 # --detach       : Run container in background and print container ID
+# --init         : Makes process PID=1 be docker-init backed by tini: https://docs.docker.com/engine/reference/run/#specify-an-init-process
 docker run --publish ${hostPort}:${containerPort} \
+           --init \
            --name ${containerName} \
            --interactive \
            --tty \

--- a/docker_environment/run_dev.sh
+++ b/docker_environment/run_dev.sh
@@ -16,7 +16,7 @@ then
       additionalVolume=""
 else
       additionalVolume="--volume $1:/home/development/Notebooks"
-      echo "Additional volume: " $additionalVolume 
+      echo "Additional volume: " $additionalVolume
 fi
 #
 # We import values from the configuration file.
@@ -25,9 +25,10 @@ source ./config.sh
 # For more info, run : docker run --help
 # --publish list : Publish a container's port(s) to the host
 # --detach       : Run container in background and print container ID
-
+# --init         : Makes process PID=1 be docker-init backed by tini: https://docs.docker.com/engine/reference/run/#specify-an-init-process
 parentDir="$(dirname "$(pwd -P)")"
 docker run --publish ${hostPort}:${containerPort} \
+           --init \
            --name ${containerName} \
            --volume $parentDir"/lib/:/home/development/lib" \
            $additionalVolume \

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "teselagen"
-version = "0.4.0"
+version = "0.4.2"
 description = "Teselagen Biotechnology API client"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 
 from setuptools import find_packages
 from setuptools import setup
+from teselagen.utils.setup_commands import SingleTestCommand
 
 #PATH_ROOT = os.path.dirname(__file__)
 
@@ -20,12 +21,17 @@ version: str = "0.0.0"
 setup_requires: List[str] = ["pytest-runner"]
 tests_require: List[str] = ["pytest"]
 
-setup(name=name,
-      version=__version__,
-      packages=find_packages(),
-      #description=description,
-      #author=author,
-      #url=url,
-      setup_requires=setup_requires,
-      #install_requires=_load_requirements(PATH_ROOT),
-      tests_require=tests_require)
+setup(
+    name=name,
+    version=__version__,
+    packages=find_packages(),
+    #description=description,
+    #author=author,
+    #url=url,
+    setup_requires=setup_requires,
+    #install_requires=_load_requirements(PATH_ROOT),
+    tests_require=tests_require,
+    cmdclass={
+        "stest": SingleTestCommand,
+    },
+)

--- a/lib/teselagen/api/test_client.py
+++ b/lib/teselagen/api/test_client.py
@@ -52,6 +52,10 @@ class TESTClient():
         self.delete_assay_subject_url: str = join(api_url_base,
                                                   "assay-subjects") + "/{}"
         self.put_assay_subject_descriptors_url: str = f"{api_url_base}/assay-subjects/descriptors"
+        ## Two endpoints for posting and getting an import job (specially useful for long running imports)
+        self.post_assay_subjects_descriptors_import_url: str = f"{api_url_base}/assay-subjects/imports"
+        self.get_assay_subjects_descriptors_import_url: str = join(
+            api_url_base, "assay-subjects/imports") + "/{}"
 
         # Experiments
         self.get_experiments_url: str = f"{api_url_base}/experiments"
@@ -67,13 +71,13 @@ class TESTClient():
         self.create_assay_url: str = join(api_url_base,
                                           "experiments") + "/{}/assays"
         self.delete_assay_url: str = join(api_url_base, "assays") + "/{}"
-
-        self.post_assay_results_import_url: str = f"{api_url_base}/assays/results/import"
-        self.get_assay_results_import_url: str = join(
-            api_url_base, "assays") + "/results/import/{}"
-
         self.assay_results_url: str = join(api_url_base,
                                            "assays") + "/{}/results"
+        ## Two endpoints for posting and getting an import job (specially useful for long running imports)
+        self.post_assay_results_import_url: str = join(api_url_base,
+                                                       "assays") + "/{}/imports"
+        self.get_assay_results_import_url: str = join(api_url_base,
+                                                      "imports") + "/{}"
 
         # Files
         self.get_files_info_url: str = f"{api_url_base}/files"
@@ -231,9 +235,6 @@ class TESTClient():
         filepath: Optional[str] = None,
         createSubjectsFromFile: Optional[bool] = False,
     ):
-        #TODO: This is a temporary implementation while a better solution
-        # for long task is implemented.
-
         # Implements the ability to do the file upload behind the scenes.
         if (file_id is None):
             if filepath is not None and (Path(filepath).exists()):
@@ -247,7 +248,7 @@ class TESTClient():
             "createSubjectsFromFile": createSubjectsFromFile
         }
         response: Dict[str, Any] = post(
-            url=self.post_assay_results_import_url,
+            url=self.post_assay_subjects_descriptors_import_url,
             headers=self.headers,
             json=body,
         )
@@ -270,7 +271,8 @@ class TESTClient():
         '''
         try:
             response: Dict[str, Any] = get(
-                url=self.get_assay_results_import_url.format(importId),
+                url=self.get_assay_subjects_descriptors_import_url.format(
+                    importId),
                 headers=self.headers,
             )
         except Exception as e:
@@ -568,13 +570,12 @@ class TESTClient():
             raise Exception(
                 f"Please provide a valid 'file_id' or an existant 'filepath'.")
         body = {
-            "assayId": assay_id,
             "fileId": file_id,
             "mapper": mapper,
         }
         try:
             response: Dict[str, Any] = post(
-                url=self.post_assay_results_import_url,
+                url=self.post_assay_results_import_url.format(assay_id),
                 headers=self.headers,
                 json=body,
             )

--- a/lib/teselagen/utils/setup_commands.py
+++ b/lib/teselagen/utils/setup_commands.py
@@ -1,0 +1,50 @@
+#   !/usr/bin/env python
+#
+#   TeselaGen Data Science Team's.
+#   Created on Aug 23, 2019 by Juan Andrés Ramírez.
+#   TeselaGen Data Science Team.
+#
+
+from pathlib import Path
+
+import pytest
+from setuptools import Command
+
+
+class SingleTestCommand(Command):
+    """
+        Single Test Command
+        ====================
+
+        This command is a helper to run single tests using pytest configuration.
+        It should be configured on setup.py to be run like this:
+
+        python3 setup.py stest -f teselagen/api/tests/test_test_client.py
+    """
+
+    description = 'runs a test on a single file'
+
+    user_options = [
+        ('file=', 'f', 'file to test'),
+        ('testname=', 't', 'test name pattern for tests in file'),
+    ]
+
+    def initialize_options(self):
+        self.file = None
+        self.testname = None
+
+    def finalize_options(self):
+        if self.file is None:
+            raise Exception("Parameter --file is missing")
+        elif not Path(self.file).is_file():
+            raise Exception("File does't exist")
+
+    def run(self):
+        # addopts = '--addopts "--pyargs {}"'.format(self.file)
+        # os.system("python3 setup.py test {}".format(addopts))
+        # Override setup.cfg configuration
+        if self.testname:
+            pytest.main(
+                [self.file, '--override-ini=addopts=-vvv', "-k", self.testname])
+        else:
+            pytest.main([self.file, '--override-ini=addopts=-vvv'])


### PR DESCRIPTION
Relates to the updates made to TEST API's Import endpoints: https://github.com/TeselaGen/lims/pull/8015

_Extras:_
 - Implements SingleTestCommand
 - Docker container run scripts include the `--init` flag to let [docker-init](https://docs.docker.com/engine/reference/run/#specify-an-init-process) take process PID=1