### PR TITLE
Cleaning of DB before tests should be linked to test host url

### DIFF
--- a/teselagen/api/client.py
+++ b/teselagen/api/client.py
@@ -292,7 +292,7 @@ class TeselaGenClient:
             # TODO : Use a logger
             print('Connection Refused')
             return None
-        print('Connection Accepted')
+        print(f'Connection Accepted at {self.host_url}')
 
         del username, password, body
 

--- a/teselagen/api/tests/test_build_client.py
+++ b/teselagen/api/tests/test_build_client.py
@@ -311,6 +311,7 @@ class TestBUILDClient:
         assert_records(records=response)
         assert len(response) <= int(pageSize)
 
+    # TODO: It would be better to dynamically define IDs, so to not be restricted to a specific instance
     @pytest.mark.parametrize(
         'aliquot_id',
         [
@@ -379,6 +380,7 @@ class TestBUILDClient:
         assert_records(records=response)
         assert len(response) <= int(pageSize)
 
+    # TODO: It would be better to dynamically define IDs, so to not be restricted to a specific instance
     @pytest.mark.parametrize(
         'sample_id',
         [


### PR DESCRIPTION
The cleaning process `clean_test_module_used_for_testing` at `conftest.py` was linked to `Client` class **default** host url, so change the `host_url` to the one that is configured for test.